### PR TITLE
Reverse treesitter queries

### DIFF
--- a/languages/nix/highlights.scm
+++ b/languages/nix/highlights.scm
@@ -1,4 +1,82 @@
-(comment) @comment
+(uri_expression) @string.special.uri
+
+[
+  (path_expression)
+  (hpath_expression)
+  (spath_expression)
+] @string.special.path
+
+[
+  (string_expression)
+  (indented_string_expression)
+] @string
+
+(identifier) @variable
+
+[
+  "("
+  ")"
+  "["
+  "]"
+  "{"
+  "}"
+] @punctuation.bracket
+
+[
+  ";"
+  "."
+  ","
+  "="
+] @punctuation.delimiter
+
+(inherit_from attrs: (inherited_attrs attr: (identifier) @property) )
+
+(identifier) @property
+
+(binding
+  attrpath: (attrpath (identifier)) @property)
+
+(variable_expression (identifier) @variable)
+
+(binary_expression
+  operator: _ @operator)
+
+(unary_expression
+  operator: _ @operator)
+
+(apply_expression
+  function: [
+    (variable_expression (identifier)) @function
+    (select_expression
+      attrpath: (attrpath
+        attr: (identifier) @function .))])
+
+(select_expression
+  attrpath: (attrpath (identifier)) @property)
+
+(formal
+  name: (identifier) @variable.parameter
+  "?"? @punctuation.delimiter)
+
+(function_expression
+  universal: (identifier) @variable.parameter
+)
+
+(dollar_escape) @escape
+(escape_sequence) @escape
+
+[
+  (integer_expression)
+  (float_expression)
+] @number
+
+((identifier) @function.builtin
+ (#match? @function.builtin "^(__add|__addErrorContext|__all|__any|__appendContext|__attrNames|__attrValues|__bitAnd|__bitOr|__bitXor|__catAttrs|__compareVersions|__concatLists|__concatMap|__concatStringsSep|__deepSeq|__div|__elem|__elemAt|__fetchurl|__filter|__filterSource|__findFile|__foldl'|__fromJSON|__functionArgs|__genList|__genericClosure|__getAttr|__getContext|__getEnv|__hasAttr|__hasContext|__hashFile|__hashString|__head|__intersectAttrs|__isAttrs|__isBool|__isFloat|__isFunction|__isInt|__isList|__isPath|__isString|__langVersion|__length|__lessThan|__listToAttrs|__mapAttrs|__match|__mul|__parseDrvName|__partition|__path|__pathExists|__readDir|__readFile|__replaceStrings|__seq|__sort|__split|__splitVersion|__storePath|__stringLength|__sub|__substring|__tail|__toFile|__toJSON|__toPath|__toXML|__trace|__tryEval|__typeOf|__unsafeDiscardOutputDependency|__unsafeDiscardStringContext|__unsafeGetAttrPos|__valueSize|abort|baseNameOf|derivation|derivationStrict|dirOf|fetchGit|fetchMercurial|fetchTarball|fromTOML|import|isNull|map|placeholder|removeAttrs|scopedImport|throw|toString)$")
+ (#is-not? local))
+
+((identifier) @variable.builtin
+ (#match? @variable.builtin "^(__currentSystem|__currentTime|__nixPath|__nixVersion|__storeDir|builtins|false|null|true)$")
+ (#is-not? local))
 
 [
   "if"
@@ -13,85 +91,7 @@
   "or"
 ] @keyword
 
-((identifier) @variable.builtin
- (#match? @variable.builtin "^(__currentSystem|__currentTime|__nixPath|__nixVersion|__storeDir|builtins|false|null|true)$")
- (#is-not? local))
-
-((identifier) @function.builtin
- (#match? @function.builtin "^(__add|__addErrorContext|__all|__any|__appendContext|__attrNames|__attrValues|__bitAnd|__bitOr|__bitXor|__catAttrs|__compareVersions|__concatLists|__concatMap|__concatStringsSep|__deepSeq|__div|__elem|__elemAt|__fetchurl|__filter|__filterSource|__findFile|__foldl'|__fromJSON|__functionArgs|__genList|__genericClosure|__getAttr|__getContext|__getEnv|__hasAttr|__hasContext|__hashFile|__hashString|__head|__intersectAttrs|__isAttrs|__isBool|__isFloat|__isFunction|__isInt|__isList|__isPath|__isString|__langVersion|__length|__lessThan|__listToAttrs|__mapAttrs|__match|__mul|__parseDrvName|__partition|__path|__pathExists|__readDir|__readFile|__replaceStrings|__seq|__sort|__split|__splitVersion|__storePath|__stringLength|__sub|__substring|__tail|__toFile|__toJSON|__toPath|__toXML|__trace|__tryEval|__typeOf|__unsafeDiscardOutputDependency|__unsafeDiscardStringContext|__unsafeGetAttrPos|__valueSize|abort|baseNameOf|derivation|derivationStrict|dirOf|fetchGit|fetchMercurial|fetchTarball|fromTOML|import|isNull|map|placeholder|removeAttrs|scopedImport|throw|toString)$")
- (#is-not? local))
-
-[
-  (integer_expression)
-  (float_expression)
-] @number
-
-(escape_sequence) @escape
-(dollar_escape) @escape
-
-(function_expression
-  universal: (identifier) @variable.parameter
-)
-
-(formal
-  name: (identifier) @variable.parameter
-  "?"? @punctuation.delimiter)
-
-(select_expression
-  attrpath: (attrpath (identifier)) @property)
-
-(apply_expression
-  function: [
-    (variable_expression (identifier)) @function
-    (select_expression
-      attrpath: (attrpath
-        attr: (identifier) @function .))])
-
-(unary_expression
-  operator: _ @operator)
-
-(binary_expression
-  operator: _ @operator)
-
-(variable_expression (identifier) @variable)
-
-(binding
-  attrpath: (attrpath (identifier)) @property)
-
-(identifier) @property
-
-(inherit_from attrs: (inherited_attrs attr: (identifier) @property) )
-
-[
-  ";"
-  "."
-  ","
-  "="
-] @punctuation.delimiter
-
-[
-  "("
-  ")"
-  "["
-  "]"
-  "{"
-  "}"
-] @punctuation.bracket
-
-(identifier) @variable
-
-[
-  (string_expression)
-  (indented_string_expression)
-] @string
-
-[
-  (path_expression)
-  (hpath_expression)
-  (spath_expression)
-] @string.special.path
-
-(uri_expression) @string.special.uri
+(comment) @comment
 
 (interpolation
   "${" @punctuation.special

--- a/languages/nix/injections.scm
+++ b/languages/nix/injections.scm
@@ -1,22 +1,14 @@
 ; mark arbitary languages with a comment
-((((comment) @injection.language) .
-  (indented_string_expression (string_fragment) @injection.content))
+(apply_expression
+  function: ((_) @_func)
+  argument: (_ (_)* (_ (_)* (binding
+    attrpath: (attrpath (identifier) @_path)
+     expression: (indented_string_expression
+       (string_fragment) @injection.content))))
+  (#match? @_func "(^|\\.)writeShellApplication$")
+  (#match? @_path "^text$")
+  (#set! injection.language "bash")
   (#set! injection.combined))
-
-((binding
-   attrpath: (attrpath (identifier) @_path)
-   expression: (indented_string_expression
-     (string_fragment) @injection.content))
- (#match? @_path "(^\\w*Phase|(pre|post)\\w*|(.*\\.)?\\w*([sS]cript|[hH]ook)|(.*\\.)?startup)$")
- (#set! injection.language "bash")
- (#set! injection.combined))
-
-((apply_expression
-   function: (apply_expression function: (_) @_func)
-   argument: (indented_string_expression (string_fragment) @injection.content))
- (#match? @_func "(^|\\.)writeShellScript(Bin)?$")
- (#set! injection.language "bash")
- (#set! injection.combined))
 
 (apply_expression
   (apply_expression
@@ -27,13 +19,21 @@
   (#set! injection.language "bash")
   (#set! injection.combined))
 
-(apply_expression
-  function: ((_) @_func)
-  argument: (_ (_)* (_ (_)* (binding
-    attrpath: (attrpath (identifier) @_path)
-     expression: (indented_string_expression
-       (string_fragment) @injection.content))))
-  (#match? @_func "(^|\\.)writeShellApplication$")
-  (#match? @_path "^text$")
-  (#set! injection.language "bash")
+((apply_expression
+   function: (apply_expression function: (_) @_func)
+   argument: (indented_string_expression (string_fragment) @injection.content))
+ (#match? @_func "(^|\\.)writeShellScript(Bin)?$")
+ (#set! injection.language "bash")
+ (#set! injection.combined))
+
+((binding
+   attrpath: (attrpath (identifier) @_path)
+   expression: (indented_string_expression
+     (string_fragment) @injection.content))
+ (#match? @_path "(^\\w*Phase|(pre|post)\\w*|(.*\\.)?\\w*([sS]cript|[hH]ook)|(.*\\.)?startup)$")
+ (#set! injection.language "bash")
+ (#set! injection.combined))
+
+((((comment) @injection.language) .
+  (indented_string_expression (string_fragment) @injection.content))
   (#set! injection.combined))


### PR DESCRIPTION
It seems the treesitter queries ported from `tree-sitter-nix` were supposed to be evaluated in reverse order. 

Before:
<img width="686" alt="Screenshot 2024-05-19 at 14 28 42" src="https://github.com/hasit/zed-nix/assets/7301807/4ca24df2-0e88-4750-ac22-9138d416ebf9">

After:
<img width="689" alt="Screenshot 2024-05-19 at 14 31 42" src="https://github.com/hasit/zed-nix/assets/7301807/51fcfd84-a6b1-4321-ad31-d800314939c4">
