### PR TITLE
Add support for nil language server

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,0 +1,3 @@
+{
+    "hard_tabs": false
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,9 +312,9 @@ dependencies = [
 
 [[package]]
 name = "zed_extension_api"
-version = "0.0.6"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ca8bcaea3feb2d2ce9dbeb061ee48365312a351faa7014c417b0365fe9e459"
+checksum = "594fd10dd0f2f853eb243e2425e7c95938cef49adb81d9602921d002c5e6d9d9"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,4 @@ path = "src/nix.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-zed_extension_api = "0.0.6"
+zed_extension_api = "0.1.0"

--- a/extension.toml
+++ b/extension.toml
@@ -10,6 +10,10 @@ repository = "https://github.com/zed-extensions/nix"
 repository = "https://github.com/nix-community/tree-sitter-nix"
 commit = "b3cda619248e7dd0f216088bd152f59ce0bbe488"
 
+[language_servers.nil]
+name = "nil"
+language = "Nix"
+
 [language_servers.nixd]
-name = "Nixd"
+name = "nixd"
 language = "Nix"

--- a/src/language_servers.rs
+++ b/src/language_servers.rs
@@ -1,0 +1,5 @@
+mod nil;
+mod nixd;
+
+pub use nil::*;
+pub use nixd::*;

--- a/src/language_servers/nil.rs
+++ b/src/language_servers/nil.rs
@@ -1,0 +1,59 @@
+use zed_extension_api::{self as zed, settings::LspSettings, LanguageServerId, Result};
+
+pub struct NilBinary {
+    pub path: String,
+    pub args: Option<Vec<String>>,
+}
+
+pub struct Nil {}
+
+impl Nil {
+    pub const LANGUAGE_SERVER_ID: &'static str = "nil";
+
+    pub fn new() -> Self {
+        Self {}
+    }
+
+    pub fn language_server_command(
+        &mut self,
+        language_server_id: &LanguageServerId,
+        worktree: &zed::Worktree,
+    ) -> Result<zed::Command> {
+        let binary = self.language_server_binary(language_server_id, worktree)?;
+
+        Ok(zed::Command {
+            command: binary.path,
+            args: binary.args.unwrap_or_else(|| vec![]),
+            env: worktree.shell_env(),
+        })
+    }
+
+    fn language_server_binary(
+        &self,
+        _language_server_id: &LanguageServerId,
+        worktree: &zed::Worktree,
+    ) -> Result<NilBinary> {
+        let binary_settings = LspSettings::for_worktree("nil", worktree)
+            .ok()
+            .and_then(|lsp_settings| lsp_settings.binary);
+        let binary_args = binary_settings
+            .as_ref()
+            .and_then(|binary_settings| binary_settings.arguments.clone());
+
+        if let Some(path) = binary_settings.and_then(|binary_settings| binary_settings.path) {
+            return Ok(NilBinary {
+                path,
+                args: binary_args,
+            });
+        }
+
+        if let Some(path) = worktree.which("nil") {
+            return Ok(NilBinary {
+                path,
+                args: binary_args,
+            });
+        }
+
+        Err("nil must be installed manually. Install it or specify the 'binary' path to it via local settings.".to_string())
+    }
+}

--- a/src/language_servers/nixd.rs
+++ b/src/language_servers/nixd.rs
@@ -1,0 +1,59 @@
+use zed_extension_api::{self as zed, settings::LspSettings, LanguageServerId, Result};
+
+pub struct NixdBinary {
+    pub path: String,
+    pub args: Option<Vec<String>>,
+}
+
+pub struct Nixd {}
+
+impl Nixd {
+    pub const LANGUAGE_SERVER_ID: &'static str = "nixd";
+
+    pub fn new() -> Self {
+        Self {}
+    }
+
+    pub fn language_server_command(
+        &mut self,
+        language_server_id: &LanguageServerId,
+        worktree: &zed::Worktree,
+    ) -> Result<zed::Command> {
+        let binary = self.language_server_binary(language_server_id, worktree)?;
+
+        Ok(zed::Command {
+            command: binary.path,
+            args: binary.args.unwrap_or_else(|| vec![]),
+            env: worktree.shell_env(),
+        })
+    }
+
+    fn language_server_binary(
+        &self,
+        _language_server_id: &LanguageServerId,
+        worktree: &zed::Worktree,
+    ) -> Result<NixdBinary> {
+        let binary_settings = LspSettings::for_worktree("nixd", worktree)
+            .ok()
+            .and_then(|lsp_settings| lsp_settings.binary);
+        let binary_args = binary_settings
+            .as_ref()
+            .and_then(|binary_settings| binary_settings.arguments.clone());
+
+        if let Some(path) = binary_settings.and_then(|binary_settings| binary_settings.path) {
+            return Ok(NixdBinary {
+                path,
+                args: binary_args,
+            });
+        }
+
+        if let Some(path) = worktree.which("nixd") {
+            return Ok(NixdBinary {
+                path,
+                args: binary_args,
+            });
+        }
+
+        Err("The Nix language server (nixd) is not available in your environment (PATH). You can install it from https://github.com/nix-community/nixd.".to_string())
+    }
+}

--- a/src/nix.rs
+++ b/src/nix.rs
@@ -1,7 +1,6 @@
 mod language_servers;
 
-use zed_extension_api::{self as zed, settings::LspSettings, LanguageServerId, Result};
-use zed::serde_json;
+use zed_extension_api::{self as zed, serde_json, settings::LspSettings, LanguageServerId, Result};
 
 use crate::language_servers::{Nil, Nixd};
 
@@ -36,18 +35,19 @@ impl zed::Extension for NixExtension {
         }
     }
 
-    fn language_server_initialization_options(
+    fn language_server_workspace_configuration(
         &mut self,
         language_server_id: &LanguageServerId,
         worktree: &zed::Worktree,
-    ) -> Result<Option<serde_json::Value>> {
-        let initialization_options =
-            LspSettings::for_worktree(language_server_id.as_ref(), worktree)
-                .ok()
-                .and_then(|lsp_settings| lsp_settings.initialization_options.clone())
-                .unwrap_or_default();
+    ) -> Result<Option<zed::serde_json::Value>> {
+        let settings = LspSettings::for_worktree(language_server_id.as_ref(), worktree)
+            .ok()
+            .and_then(|lsp_settings| lsp_settings.settings.clone())
+            .unwrap_or_default();
 
-        Ok(Some(serde_json::json!(initialization_options)))
+        let mut map = serde_json::Map::new();
+        map.insert(language_server_id.to_string(), settings);
+        Ok(Some(serde_json::json!(map)))
     }
 }
 

--- a/src/nix.rs
+++ b/src/nix.rs
@@ -1,28 +1,53 @@
-use zed_extension_api::{self as zed, LanguageServerId, Result};
+mod language_servers;
 
-struct NixExtension;
+use zed_extension_api::{self as zed, settings::LspSettings, LanguageServerId, Result};
+use zed::serde_json;
+
+use crate::language_servers::{Nil, Nixd};
+
+struct NixExtension {
+    nil: Option<Nil>,
+    nixd: Option<Nixd>,
+}
 
 impl zed::Extension for NixExtension {
     fn new() -> Self {
-        Self
+        Self {
+            nil: None,
+            nixd: None,
+        }
     }
 
     fn language_server_command(
         &mut self,
-        _: &LanguageServerId,
+        language_server_id: &LanguageServerId,
         worktree: &zed::Worktree,
     ) -> Result<zed::Command> {
-        let path = worktree.which("nixd").ok_or_else(|| {
-            "The Nix language server (nixd) is not available in your environment (PATH).
-                You can install it from https://github.com/nix-community/nixd."
-                .to_string()
-        })?;
+        match language_server_id.as_ref() {
+            Nil::LANGUAGE_SERVER_ID => {
+                let nil = self.nil.get_or_insert_with(Nil::new);
+                nil.language_server_command(language_server_id, worktree)
+            }
+            Nixd::LANGUAGE_SERVER_ID => {
+                let nixd = self.nixd.get_or_insert_with(Nixd::new);
+                nixd.language_server_command(language_server_id, worktree)
+            }
+            language_server_id => Err(format!("unknown language server: {language_server_id}")),
+        }
+    }
 
-        Ok(zed::Command {
-            command: path,
-            args: vec![],
-            env: vec![],
-        })
+    fn language_server_initialization_options(
+        &mut self,
+        language_server_id: &LanguageServerId,
+        worktree: &zed::Worktree,
+    ) -> Result<Option<serde_json::Value>> {
+        let initialization_options =
+            LspSettings::for_worktree(language_server_id.as_ref(), worktree)
+                .ok()
+                .and_then(|lsp_settings| lsp_settings.initialization_options.clone())
+                .unwrap_or_default();
+
+        Ok(Some(serde_json::json!(initialization_options)))
     }
 }
 


### PR DESCRIPTION
Closes #9
Supersedes #7 

## Configure Nixd

Options: <https://github.com/nix-community/nixd/blob/main/nixd/docs/configuration.md>

Example:
[`settings.json`](https://zed.dev/docs/configuring-zed#settings-files)
```json
{
	"lsp": {
		"nixd": {
			"settings": {
				"diagnostic": {
					"suppress": [ "sema-extra-with" ]
				}
			}
		}
	}
}
```

## Configure Nil

Options: <https://github.com/oxalica/nil/blob/main/docs/configuration.md>

Example:
[`settings.json`](https://zed.dev/docs/configuring-zed#settings-files)
```json
{
	"lsp": {
		"nil": {
			"settings": {
 				"diagnostics": {
					"ignored": [ "unused_binding" ]
				}
			}
		}
	}
}
```

## Only use Nixd

[`settings.json`](https://zed.dev/docs/configuring-zed#settings-files)
```json
{
	"languages": {
		"Nix": {
			"language_servers": [ "nixd", "!nil" ],
		}
	}
}

```

## Only use Nil

[`settings.json`](https://zed.dev/docs/configuring-zed#settings-files)
```json
{
	"languages": {
		"Nix": {
			"language_servers": [ "nil", "!nixd" ],
		}
	}
}

```