### PR TITLE
Update language/nix/config.toml: Proper single quote support

### DIFF
--- a/languages/nix/config.toml
+++ b/languages/nix/config.toml
@@ -8,6 +8,6 @@ brackets = [
     { start = "[", end = "]", close = true, newline = false },
     { start = "(", end = ")", close = true, newline = false },
     { start = "${", end = "}", close = true, newline = false },
-    { start = "'", end = "'", close = true, newline = false, not_in = ["comment", "string"] },
+    { start = "''", end = "''", close = true, newline = true, not_in = ["comment", "string"] },
     { start = "\"", end = "\"", close = true, newline = false, not_in = ["comment", "string"] },
 ]


### PR DESCRIPTION
See https://nix.dev/manual/nix/2.18/language/values#type-string.

Currently, a single `'` auto-closes, which is very annoying for identifiers like `builtins.foldl'`, and an actual single-quoted string which is opened/closed by `''` doesn't auto-close, and doesn't do newlines by default. 