### PR TITLE
fix: #11 language defaults to match RFC 166

### DIFF
--- a/languages/nix/config.toml
+++ b/languages/nix/config.toml
@@ -11,3 +11,5 @@ brackets = [
     { start = "''", end = "''", close = true, newline = true, not_in = ["comment", "string"] },
     { start = "\"", end = "\"", close = true, newline = false, not_in = ["comment", "string"] },
 ]
+tab_size = 2
+hard_tabs = false


### PR DESCRIPTION
Related: <https://github.com/zed-industries/zed/pull/20794>