### PR TITLE
Fix language injections which are indicated by a comment preceding a string

### DIFF
--- a/languages/nix/injections.scm
+++ b/languages/nix/injections.scm
@@ -1,28 +1,28 @@
-; ((comment) @content
-;   (#set! language "comment"))
+((comment) @content
+  (#set! language "comment"))
 
-; ((comment) @language
-;   . ; this is to make sure only adjacent comments are accounted for the injections
-;   [
-;     (string_expression
-;       (string_fragment) @content)
-;     (indented_string_expression
-;       (string_fragment) @content)
-;   ]
-;   (#gsub! @language "/%*%s*([%w%p]+)%s*%*/" "%1")
-;   (#set! combined))
+((comment) @language
+  . ; this is to make sure only adjacent comments are accounted for the injections
+  [
+    (string_expression
+      (string_fragment) @content)
+    (indented_string_expression
+      (string_fragment) @content)
+  ]
+  (#gsub! @language "/%*%s*([%w%p]+)%s*%*/" "%1")
+  (#set! combined))
 
-; ; #-style Comments
-; ((comment) @language
-;   . ; this is to make sure only adjacent comments are accounted for the injections
-;   [
-;     (string_expression
-;       (string_fragment) @content)
-;     (indented_string_expression
-;       (string_fragment) @content)
-;   ]
-;   (#gsub! @language "#%s*([%w%p]+)%s*" "%1")
-;   (#set! combined))
+; #-style Comments
+((comment) @language
+  . ; this is to make sure only adjacent comments are accounted for the injections
+  [
+    (string_expression
+      (string_fragment) @content)
+    (indented_string_expression
+      (string_fragment) @content)
+  ]
+  (#gsub! @language "#%s*([%w%p]+)%s*" "%1")
+  (#set! combined))
 
 (apply_expression
   function: (_) @_func


### PR DESCRIPTION
@matubu I think this was accidentally commented out (https://github.com/zed-extensions/nix/pull/16#discussion_r1948288715)

Feel free to close the request if not.