### PR TITLE
Remove `none` bracket highlight

### DIFF
--- a/languages/nix/highlights.scm
+++ b/languages/nix/highlights.scm
@@ -319,7 +319,7 @@
 (interpolation
   "${" @punctuation.special
   (_)
-  "}" @punctuation.special) @none
+  "}" @punctuation.special)
 
 (select_expression
   expression: (_) @_expr


### PR DESCRIPTION
Related: https://github.com/zed-extensions/nix/issues/29

No theme has a definion for the `none` highlight and it causes issues with bracket highlighting, see the linked issue.