### PR TITLE
Add runnable tasks and dynamic comment-based language injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,22 @@ See: [Nil LSP Configuration Docs](https://github.com/oxalica/nil/blob/main/docs/
 }
 ```
 
+## Runnable tasks
+
+The extension detects flake output bindings (`packages`, `checks`, `devShells`, `apps`, `formatter`) and shows run buttons in the gutter. Clicking a button opens a task picker with relevant actions:
+
+| Output | Actions |
+|--------|---------|
+| `packages` | nix build, nix run, nix build --debugger |
+| `checks` | nix check, nix flake check (all), nix check --debugger |
+| `devShells` | nix develop, nix develop (impure), nix develop --debugger |
+| `apps` | nix run, nix run --debugger |
+| `formatter` | nix fmt, nix fmt --check |
+
+Both 2-level (`packages.default`) and 3-level (`packages.x86_64-linux.default`) attrpath patterns are supported.
+
+The `--debugger` variants launch the [Nix debugger](https://nix.dev/manual/nix/latest/command-ref/nix-build#opt-debugger), which drops into an interactive REPL on evaluation errors or `builtins.break` calls. Useful commands: `:bt` (backtrace), `:env` (show variables), `:continue`, `:step`.
+
 ### Configure formatters
 
 You can configure formatters through LSP:

--- a/extension.toml
+++ b/extension.toml
@@ -7,8 +7,8 @@ authors = ["Hasit Mistry <hasitnm@gmail.com>"]
 repository = "https://github.com/zed-extensions/nix"
 
 [grammars.nix]
-repository = "https://github.com/nix-community/tree-sitter-nix"
-commit = "ea1d87f7996be1329ef6555dcacfa63a69bd55c6"
+repository = "https://github.com/sebb3/tree-sitter-nix"
+commit = "1c903f05d9ff4b74f0836018729ecbefdd0fbdd0"
 
 [language_servers.nil]
 name = "nil"

--- a/languages/nix/highlights.scm
+++ b/languages/nix/highlights.scm
@@ -20,6 +20,7 @@
 
 ; comments
 (comment) @comment ; @spell
+(injection_comment) @comment
 
 ; strings
 (string_fragment) @string

--- a/languages/nix/injections.scm
+++ b/languages/nix/injections.scm
@@ -1,6 +1,31 @@
 ((comment) @content
     (#set! injection.language "comment"))
 
+; ============================================================================
+; Comment-based language injection (dynamic)
+; ============================================================================
+; Place a comment containing the language name directly before a string
+; to inject syntax highlighting for that language. For example:
+;
+;   # bash
+;   ''
+;     echo "hello"
+;   ''
+;
+; Also works with block comments: /* python */ "print('hi')"
+;
+; Requires tree-sitter-nix with injection_comment support.
+; ============================================================================
+
+((injection_comment (injection_language) @language) .
+  [(indented_string_expression (string_fragment) @content)
+   (string_expression (string_fragment) @content)]
+  (#set! combined))
+
+; ============================================================================
+; Function-based injections
+; ============================================================================
+
 (apply_expression
   function: (_) @_func
   argument: [

--- a/languages/nix/runnables.scm
+++ b/languages/nix/runnables.scm
@@ -1,0 +1,93 @@
+; ============================================================================
+; Nix flake output runnables
+; ============================================================================
+; Detects flake output attribute bindings and tags them for task templates.
+; Works with both 3-level (e.g. packages.<system>.<name>) and 2-level
+; (e.g. packages.<name>, inside forAllSystems/eachSystem) attrpath patterns.
+;
+; Captures:
+;   @run   - where the run button appears (on the output name)
+;   @name  - the flake output name (-> $ZED_CUSTOM_name)
+;
+; Users must configure task templates in .zed/tasks.json to use these tags.
+; Example task template for nix-build:
+;   {
+;     "label": "nix build .#$ZED_CUSTOM_name",
+;     "command": "nix",
+;     "args": ["build", ".#$ZED_CUSTOM_name"],
+;     "tags": ["nix-build"]
+;   }
+; ============================================================================
+
+; --- packages ---
+(
+  (binding
+    attrpath: (attrpath
+      . (identifier) @_category
+      (identifier) @run @name .)
+    (#eq? @_category "packages")) @_nix-package
+  (#set! tag nix-package)
+)
+
+; --- checks (3-level: checks.<system>.<name>) ---
+; Captures @system for use in task templates as $ZED_CUSTOM_system.
+; Only matches 3-level attrpaths; 2-level (forAllSystems) checks
+; won't get a per-check button — use "nix flake check" from the task palette.
+(
+  (binding
+    attrpath: (attrpath
+      . (identifier) @_category
+      (identifier) @system
+      (identifier) @run @name .)
+    (#eq? @_category "checks")) @_nix-check
+  (#set! tag nix-check)
+)
+
+; --- devShells ---
+(
+  (binding
+    attrpath: (attrpath
+      . (identifier) @_category
+      (identifier) @run @name .)
+    (#eq? @_category "devShells")) @_nix-develop
+  (#set! tag nix-develop)
+)
+
+; --- apps ---
+(
+  (binding
+    attrpath: (attrpath
+      . (identifier) @_category
+      (identifier) @run @name .)
+    (#eq? @_category "apps")) @_nix-run
+  (#set! tag nix-run)
+)
+
+; --- formatter (1-level, inside forAllSystems/eachSystem) ---
+(
+  (binding
+    attrpath: (attrpath
+      . (identifier) @run @_category .)
+    (#eq? @_category "formatter")) @_nix-fmt
+  (#set! tag nix-fmt)
+)
+
+; --- formatter (2-level, with system identifier) ---
+(
+  (binding
+    attrpath: (attrpath
+      . (identifier) @_category
+      (identifier) @run .)
+    (#eq? @_category "formatter")) @_nix-fmt
+  (#set! tag nix-fmt)
+)
+
+; --- formatter (2-level, with system interpolation e.g. ${system}) ---
+(
+  (binding
+    attrpath: (attrpath
+      . (identifier) @_category
+      (interpolation) @run .)
+    (#eq? @_category "formatter")) @_nix-fmt
+  (#set! tag nix-fmt)
+)

--- a/languages/nix/tasks.json
+++ b/languages/nix/tasks.json
@@ -1,0 +1,80 @@
+[
+  {
+    "label": "nix build: $ZED_CUSTOM_name",
+    "command": "nix",
+    "args": ["build", ".#$ZED_CUSTOM_name"],
+    "tags": ["nix-package"]
+  },
+  {
+    "label": "nix run: $ZED_CUSTOM_name",
+    "command": "nix",
+    "args": ["run", ".#$ZED_CUSTOM_name"],
+    "tags": ["nix-package"]
+  },
+  {
+    "label": "nix build --debugger: $ZED_CUSTOM_name",
+    "command": "nix",
+    "args": ["build", "--debugger", ".#$ZED_CUSTOM_name"],
+    "tags": ["nix-package"]
+  },
+  {
+    "label": "nix check: $ZED_CUSTOM_name",
+    "command": "nix",
+    "args": ["build", ".#checks.$ZED_CUSTOM_system.$ZED_CUSTOM_name"],
+    "tags": ["nix-check"]
+  },
+  {
+    "label": "nix flake check (all)",
+    "command": "nix",
+    "args": ["flake", "check"],
+    "tags": ["nix-check"]
+  },
+  {
+    "label": "nix check --debugger: $ZED_CUSTOM_name",
+    "command": "nix",
+    "args": ["build", "--debugger", ".#checks.$ZED_CUSTOM_system.$ZED_CUSTOM_name"],
+    "tags": ["nix-check"]
+  },
+  {
+    "label": "nix develop: $ZED_CUSTOM_name",
+    "command": "nix",
+    "args": ["develop", ".#$ZED_CUSTOM_name"],
+    "tags": ["nix-develop"]
+  },
+  {
+    "label": "nix develop --impure: $ZED_CUSTOM_name",
+    "command": "nix",
+    "args": ["develop", "--impure", ".#$ZED_CUSTOM_name"],
+    "tags": ["nix-develop"]
+  },
+  {
+    "label": "nix develop --debugger: $ZED_CUSTOM_name",
+    "command": "nix",
+    "args": ["develop", "--debugger", ".#$ZED_CUSTOM_name"],
+    "tags": ["nix-develop"]
+  },
+  {
+    "label": "nix run: $ZED_CUSTOM_name",
+    "command": "nix",
+    "args": ["run", ".#$ZED_CUSTOM_name"],
+    "tags": ["nix-run"]
+  },
+  {
+    "label": "nix run --debugger: $ZED_CUSTOM_name",
+    "command": "nix",
+    "args": ["run", "--debugger", ".#$ZED_CUSTOM_name"],
+    "tags": ["nix-run"]
+  },
+  {
+    "label": "nix fmt",
+    "command": "nix",
+    "args": ["fmt"],
+    "tags": ["nix-fmt"]
+  },
+  {
+    "label": "nix fmt --check",
+    "command": "nix",
+    "args": ["fmt", "--", "--check"],
+    "tags": ["nix-fmt"]
+  }
+]


### PR DESCRIPTION
## Summary

- **Runnable tasks for flake outputs**: Detects `packages`, `checks`, `devShells`, `apps`, and `formatter` bindings in flake files and exposes them as runnable tasks in the editor gutter. Supports both 2-level and 3-level attrpath patterns.
- **Dynamic comment-based language injection**: Place a comment containing a language name (e.g. `# bash`, `/* python */`) before a string to inject syntax highlighting for that language. Works for **any language** Zed knows about — no hardcoded list needed. Uses the new `injection_comment` grammar node.

## Runnable tasks

| Output | Actions |
|--------|---------|
| `packages` | nix build, nix run, nix build --debugger |
| `checks` | nix check, nix flake check (all), nix check --debugger |
| `devShells` | nix develop, nix develop (impure), nix develop --debugger |
| `apps` | nix run, nix run --debugger |
| `formatter` | nix fmt, nix fmt --check |

## Dynamic injection example

```nix
# bash
''
  echo "hello"
''

/* python */
"print('hi')"
```

## Dependencies

- Grammar: `sebb3/tree-sitter-nix@injection-comment` — see nix-community/tree-sitter-nix#166 (pending upstream merge). Once merged, `extension.toml` will be updated to point back to `nix-community/tree-sitter-nix`.


Closes #25 #26 