### PR TITLE
treat '-' as word

### DIFF
--- a/languages/nix/config.toml
+++ b/languages/nix/config.toml
@@ -1,6 +1,8 @@
 name = "Nix"
 grammar = "nix"
 path_suffixes = ["nix"]
+word_characters = ["-"]
+completion_query_characters = ["-"]
 line_comments = ["# "]
 autoclose_before = ";:.,=}])>` \n\t\""
 brackets = [


### PR DESCRIPTION
Hyphens are now in `completion_query_characters`, and they no longer stop autocompletions mid-word.

This fixes the issue of words like `start-end` being autocompleted into `start-start-end`.

Hyphens are also included in `word_characters`, so this fixes the issue of double-clicking `start-end` in the `start` area only selected the word `start`, which is awkward behaviour considering `start-end` would be considered as a single token in nix.